### PR TITLE
Issue10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules/
 dist/
-pkg/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+pkg/

--- a/README.md
+++ b/README.md
@@ -67,3 +67,27 @@ const result = await auth
 ```shell
 openapi-generator generate -g typescript-axios -i swagger.yaml -o ./src
 ```
+
+## Create WASM and Javascript interface with Rust
+
+```shell
+cd src/tendermint/sr25519
+cargo install wasm-pack
+cargo build --target=wasm32-unknown-unknown --release
+wasm-pack build --scope lcnem
+```
+
+You can see generated ./pkg included these files.
+
+./pkg
+
+```
+-rw-rw-r-- 1 nao nao    1  6月 19 20:28 .gitignore
+-rw-r--r-- 1 nao nao  102  6月 19 20:28 README.md
+-rw-rw-r-- 1 nao nao 2.3K  6月 19 20:28 crypto.d.ts
+-rw-rw-r-- 1 nao nao   73  6月 19 20:28 crypto.js
+-rw-rw-r-- 1 nao nao  768  6月 19 20:28 crypto_bg.d.ts
+-rw-rw-r-- 1 nao nao 5.4K  6月 19 20:28 crypto_bg.js
+-rw-rw-r-- 1 nao nao 204K  6月 19 20:28 crypto_bg.wasm
+-rw-rw-r-- 1 nao nao  284  6月 19 20:28 package.json
+```

--- a/src/tendermint/sr25519/.gitignore
+++ b/src/tendermint/sr25519/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+/pkg

--- a/src/tendermint/sr25519/Cargo.toml
+++ b/src/tendermint/sr25519/Cargo.toml
@@ -12,11 +12,15 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 wasm-bindgen = "0.2.62"
 wee_alloc = "0.4.3"
-schnorrkel = { version = "0.9.1", features = ["nightly", "preaudit_deprecated", "u64_backend"] }
+# Feature attributes are may only allowed on the nightly release.
+# schnorrkel = { version = "0.9.1", features = ["nightly", "preaudit_deprecated", "u64_backend"] }
+schnorrkel = "0.9.1"
 
 [dev-dependencies]
 hex-literal = "0.2.0"
-rand = { version = "0.7.3", features = ["wasm-bindgen"] }
+# Feature attributes are may only allowed on the nightly release.
+# rand = { version = "0.7.3", features = ["wasm-bindgen"] }
+rand = "0.7.3"
 
 [profile.release]
 lto = true

--- a/src/tendermint/sr25519/src/index.js
+++ b/src/tendermint/sr25519/src/index.js
@@ -1,5 +1,5 @@
 // wasm
-const stubbed = require("./sr25519");
+const stubbed = require("../pkg/crypto");
 
 module.exports.deriveKeypairHard = stubbed.derive_keypair_hard;
 module.exports.deriveKeypairSoft = stubbed.derive_keypair_soft;


### PR DESCRIPTION
WASMへのコンパイル方法、生成されたWASMをJSから利用するための方法を調査後、

1. コンパイル時にエラーになったCargo.toml の設定箇所を調整
1. RustコードからWASMのコンパイル
1. WASMをJSから利用できるように、 index.js の require文を変更

コンパイル方法はいくつか存在したのですが、最終的には wasm-pack を使うことにしました。

https://rustwasm.github.io/wasm-pack/book/introduction.html
