### PR TITLE
[WIP] #15  update build setting for wasm

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,27 +67,3 @@ const result = await auth
 ```shell
 openapi-generator generate -g typescript-axios -i swagger.yaml -o ./src
 ```
-
-## Create WASM and Javascript interface with Rust
-
-```shell
-cd src/tendermint/sr25519
-cargo install wasm-pack
-cargo build --target=wasm32-unknown-unknown --release
-wasm-pack build --scope lcnem
-```
-
-You can see generated ./pkg included these files.
-
-./pkg
-
-```
--rw-rw-r-- 1 nao nao    1  6月 19 20:28 .gitignore
--rw-r--r-- 1 nao nao  102  6月 19 20:28 README.md
--rw-rw-r-- 1 nao nao 2.3K  6月 19 20:28 crypto.d.ts
--rw-rw-r-- 1 nao nao   73  6月 19 20:28 crypto.js
--rw-rw-r-- 1 nao nao  768  6月 19 20:28 crypto_bg.d.ts
--rw-rw-r-- 1 nao nao 5.4K  6月 19 20:28 crypto_bg.js
--rw-rw-r-- 1 nao nao 204K  6月 19 20:28 crypto_bg.wasm
--rw-rw-r-- 1 nao nao  284  6月 19 20:28 package.json
-```

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "test": "jest",
-    "build": "tsc --build --clean && tsc",
+    "build": "tsc --build --clean && tsc && cargo install wasm-pack && wasm-pack build --scope lcnem ./src/tendermint/sr25519",
     "publish": "node bundle && cd dist && npm publish"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cosmos-client",
   "description": "REST API Client for Cosmos SDK Blockchain",
-  "version": "0.8.2",
+  "version": "0.8.4",
   "author": "LCNEM, Inc.",
   "bugs": {
     "url": "https://github.com/lcnem/cosmos-client-ts/issues"
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "test": "jest",
-    "build": "tsc --build --clean && tsc && cargo install wasm-pack && wasm-pack build --scope lcnem ./src/tendermint/sr25519",
+    "build": "tsc --build --clean && tsc && cargo install wasm-pack && wasm-pack build --target nodejs --scope lcnem ./src/tendermint/sr25519",
     "publish": "node bundle && cd dist && npm publish"
   }
 }


### PR DESCRIPTION
調整しました。

以下の実行結果は、 `cargo install wasm-pack` がインストール済みの場合です。
インストールされていなければ、インストールされます。

READMEに追加した **Create WASM and Javascript interface with Rust** はいらないかもしれないですね。
その代わりにビルド必須条件として、Rustがインストールされていることを明記した方が良いかもしれません。

```shell
npm run build

> cosmos-client@0.8.2 build /home/nao/wip/cosmos-client-ts
> tsc --build --clean && tsc && cargo install wasm-pack && wasm-pack build --scope lcnem ./src/tendermint/sr25519

    Updating crates.io index
     Ignored package `wasm-pack v0.9.1` is already installed, use --force to override
[INFO]: Checking for the Wasm target...
[INFO]: Compiling to Wasm...
    Finished release [optimized] target(s) in 0.06s
[INFO]: Installing wasm-bindgen...
[INFO]: Optimizing wasm binaries with `wasm-opt`...
[INFO]: Optional fields missing from Cargo.toml: 'description', 'repository', and 'license'. These are not necessary, but recommended
[INFO]: :-) Done in 1.74s
[INFO]: :-) Your wasm pkg is ready to publish at ./src/tendermint/sr25519/pkg.
```